### PR TITLE
Audio toggle and LP 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Losing or gaining life causes the classic animation and sound effects.
 Swipe left and right to navigate between 2 different players.
 
 Tap on the top 3rd of the screen to enter the gain life calculator.
-Tap on the center of the screen to enter the set life total calculator.
+Tap in the center of the screen to enter the set life total calculator.
 Tap on the bottom 3rd of the screen to enter the reduce life total calculator.
 
 In the calculator, you can toggle between the 3 modes by pressing the operator button.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     implementation(libs.activity.compose)
     implementation(libs.core.splashscreen)
     implementation(libs.compose.ui.tooling)
+    implementation(libs.material.icons.extended)
     implementation(libs.horologist.compose.layout)
     implementation(libs.datastore.preferences)
     androidTestImplementation(platform(libs.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         minSdk = 33
         targetSdk = 36
         versionCode = 11
-        versionName = "2.6.0"
+        versionName = "2.7.0"
 
     }
 

--- a/app/src/main/java/com/finoldigital/ygolp/presentation/LifePointsActivity.kt
+++ b/app/src/main/java/com/finoldigital/ygolp/presentation/LifePointsActivity.kt
@@ -12,6 +12,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -20,12 +24,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
@@ -58,6 +62,8 @@ fun LifePointsScreen(
     onSwipePlayer: () -> Unit,
     playerId: Int = 1,
     onRestart: (() -> Unit)? = null,
+    isMuted: Boolean = false,
+    onToggleMute: () -> Unit = {},
 ) {
     val isLost = displayedLifePoints <= 0 && onRestart != null
     Box(
@@ -128,6 +134,23 @@ fun LifePointsScreen(
                 .padding(bottom = 16.dp), // Adjust padding as needed
             playerId = playerId
         )
+
+        // Mute/Unmute toggle button at top center
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 4.dp)
+                .size(48.dp)
+                .clickable { onToggleMute() },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = if (isMuted) Icons.AutoMirrored.Filled.VolumeOff else Icons.AutoMirrored.Filled.VolumeUp,
+                contentDescription = if (isMuted) "Unmute" else "Mute",
+                tint = Color.White.copy(alpha = 0.7f),
+                modifier = Modifier.size(32.dp)
+            )
+        }
     }
 }
 
@@ -138,7 +161,7 @@ fun LifePointsText(displayedLifePoints: Int) {
         contentAlignment = Alignment.Center
     ) {
         val lifePointsText =
-            if (displayedLifePoints > 0) displayedLifePoints.toString() else stringResource(R.string.app_name)
+            if (displayedLifePoints > 0) displayedLifePoints.toString() else 0.toString()
         Text(
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center,

--- a/app/src/main/java/com/finoldigital/ygolp/presentation/LifePointsActivity.kt
+++ b/app/src/main/java/com/finoldigital/ygolp/presentation/LifePointsActivity.kt
@@ -161,7 +161,7 @@ fun LifePointsText(displayedLifePoints: Int) {
         contentAlignment = Alignment.Center
     ) {
         val lifePointsText =
-            if (displayedLifePoints > 0) displayedLifePoints.toString() else 0.toString()
+            if (displayedLifePoints > 0) displayedLifePoints.toString() else "0"
         Text(
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Center,

--- a/app/src/main/java/com/finoldigital/ygolp/presentation/MainActivity.kt
+++ b/app/src/main/java/com/finoldigital/ygolp/presentation/MainActivity.kt
@@ -10,9 +10,11 @@ import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -40,12 +42,14 @@ class MainActivity : ComponentActivity() {
     companion object {
         val LIFE_POINTS_P1_DS_KEY = intPreferencesKey("life_points_p1")
         val LIFE_POINTS_P2_DS_KEY = intPreferencesKey("life_points_p2")
+        val IS_MUTED_DS_KEY = booleanPreferencesKey("is_muted")
     }
 
     private var lifePoints by mutableIntStateOf(0)
     private var displayedLifePoints by mutableIntStateOf(0)
     private var lifePoints2 by mutableIntStateOf(0)
     private var displayedLifePoints2 by mutableIntStateOf(0)
+    private var isMuted by mutableStateOf(false)
 
     private var duelStartMP: MediaPlayer? = null
     private var lifePointsChangeMP: MediaPlayer? = null
@@ -59,6 +63,7 @@ class MainActivity : ComponentActivity() {
             val preferences = dataStore.data.first()
             lifePoints = preferences[LIFE_POINTS_P1_DS_KEY] ?: 0
             lifePoints2 = preferences[LIFE_POINTS_P2_DS_KEY] ?: 0
+            isMuted = preferences[IS_MUTED_DS_KEY] ?: false
         }
         displayedLifePoints = lifePoints
         displayedLifePoints2 = lifePoints2
@@ -121,6 +126,10 @@ class MainActivity : ComponentActivity() {
     }
 
     fun start() {
+        if (isMuted) {
+            restart()
+            return
+        }
         if (itsTimeToDuelMP == null) {
             itsTimeToDuelMP = MediaPlayer.create(this, R.raw.its_time_to_duel)
             itsTimeToDuelMP?.setOnCompletionListener {
@@ -130,6 +139,15 @@ class MainActivity : ComponentActivity() {
             }
         }
         itsTimeToDuelMP?.start()
+    }
+
+    fun toggleMute() {
+        isMuted = !isMuted
+        lifecycleScope.launch {
+            dataStore.edit { settings ->
+                settings[IS_MUTED_DS_KEY] = isMuted
+            }
+        }
     }
 
     fun restart() {
@@ -144,6 +162,12 @@ class MainActivity : ComponentActivity() {
         }
         displayedLifePoints = 0
         displayedLifePoints2 = 0
+
+        if (isMuted) {
+            changeLifePoints(STARTING_LIFE_POINTS, 1, playSound = false)
+            changeLifePoints(STARTING_LIFE_POINTS, 2, playSound = false)
+            return
+        }
 
         if (duelStartMP == null) {
             duelStartMP = MediaPlayer.create(this, R.raw.duel_start)
@@ -174,7 +198,7 @@ class MainActivity : ComponentActivity() {
                     }
                 }
             }
-            if (playSound) {
+            if (playSound && !isMuted) {
                 if (lifePointsChangeMP == null) {
                     lifePointsChangeMP = MediaPlayer.create(this, R.raw.lifepoints_change)
                     lifePointsChangeMP?.setOnCompletionListener {
@@ -212,6 +236,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun startItsTimeToDuel() {
+        if (isMuted) return
         if (itsTimeToDuelMP == null) {
             itsTimeToDuelMP = MediaPlayer.create(this, R.raw.its_time_to_duel)
             itsTimeToDuelMP?.setOnCompletionListener {
@@ -271,7 +296,9 @@ class MainActivity : ComponentActivity() {
                             onShowCalculatorWithMode = { mode -> navController.navigate("calculator/1/$mode") },
                             onSwipePlayer = { navController.navigate("lifepoints/2") },
                             playerId = player,
-                            onRestart = if (displayedLifePoints <= 0) ({ start() }) else null
+                            onRestart = if (displayedLifePoints <= 0) ({ start() }) else null,
+                            isMuted = isMuted,
+                            onToggleMute = { toggleMute() }
                         )
                     } else {
                         LifePointsScreen(
@@ -279,7 +306,9 @@ class MainActivity : ComponentActivity() {
                             onShowCalculatorWithMode = { mode -> navController.navigate("calculator/2/$mode") },
                             onSwipePlayer = { navController.popBackStack() },
                             playerId = player,
-                            onRestart = if (displayedLifePoints2 <= 0) ({ start() }) else null
+                            onRestart = if (displayedLifePoints2 <= 0) ({ start() }) else null,
+                            isMuted = isMuted,
+                            onToggleMute = { toggleMute() }
                         )
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ wear-tooling-preview = { group = "androidx.wear", name = "wear-tooling-preview",
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
 compose-ui-tooling = { group = "androidx.wear.compose", name = "compose-ui-tooling", version.ref = "composeUiTooling" }
+material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 
 [plugins]


### PR DESCRIPTION
Audio toggle and LP 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mute/unmute button added to the life points screen to control match audio.
  * Mute preference now persists between app sessions.

* **User-facing Fixes**
  * Life points display now shows "0" when a player's points are non-positive.

* **Chores**
  * App version bumped to 2.7.0.

* **Documentation**
  * Clarified tap gesture wording in usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->